### PR TITLE
Fix rexec for qemu-arm

### DIFF
--- a/tools/qemu-arm.sh
+++ b/tools/qemu-arm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-qemu-system-arm -M versatilepb -m 512M -nographic -monitor null -serial null -semihosting -kernel "$*"
+qemu-system-arm -M versatilepb -m 512M -nographic -monitor null -serial null -semihosting -kernel "$@"


### PR DESCRIPTION
Fixes the following problem when running `./build.sh -k linux qemu-arm` :

```console
$ RUMP_VERBOSE=1 /home/sho/work/frankenlibc-arm/rump/bin/rexec /home/sho/work/frankenlibc-arm/rumpobj/tests/hello disk.img
/home/sho/work/frankenlibc-arm/rumpobj/tests/hello disk.img: No such file or directory
qemu: could not load kernel '/home/sho/work/frankenlibc-arm/rumpobj/tests/hello disk.img'
```